### PR TITLE
fix: comma characters in cell values break up 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const md = require("markdown-it")();
-const csvToMarkdown = require("csv-to-markdown-table");
+const TableBuilder = require("nd-table").Table;
 const groupBy = require("group-by");
 const stringMath = require("string-math");
 
@@ -167,16 +167,12 @@ const generateTableTokens = (table) => {
     )
   );
 
-  const aggregatedGroups = groups
-    .map(aggregate)
-    .map((aggregatedRow) => aggregatedRow.join(","));
+  const tableBuilder = TableBuilder.fromData(
+    [table.visibleColumns.map((col) => col.name), ...groups.map(aggregate)],
+    true // this indicates that the first row is the column header.
+  );
 
-  const csv = [
-    table.visibleColumns.map((col) => col.name).join(","), // header
-    ...aggregatedGroups, // groups
-  ];
-
-  const stringified = csvToMarkdown(csv.join("\n"), ",", true);
+  const stringified = tableBuilder.toMarkdown();
   const tokens = md.parse(stringified);
   return tokens;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-it-pivot-table",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-it-pivot-table",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "group-by": "^0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "csv-to-markdown-table": "^1.3.1",
         "group-by": "^0.0.1",
+        "nd-table": "^1.2.2",
         "string-math": "^1.2.2"
       },
       "devDependencies": {
@@ -27,11 +27,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz",
       "integrity": "sha512-69pIRJs9fCCHRqCz3390YF2LV1Lu6iEMZ5zuVqqUn+G20V9BNXlMs0cWawWeW9g4Ynmg29JmkG6R7/lUJoGd1Q=="
-    },
-    "node_modules/csv-to-markdown-table": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/csv-to-markdown-table/-/csv-to-markdown-table-1.3.1.tgz",
-      "integrity": "sha512-ocr1MXWLFrc7la7fE4/2876XsBc9ajCeYZnXJrszSdyyIWMSVOYTg/Ol9W1xku8SZxBNsFhNECNmiZqo6OPsEg=="
     },
     "node_modules/entities": {
       "version": "3.0.1",
@@ -83,6 +78,11 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
+    },
+    "node_modules/nd-table": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nd-table/-/nd-table-1.2.2.tgz",
+      "integrity": "sha512-T/ALZyo4g15iRJ9TK7mo9Ny0CQvYcDGSZ8k9/6/CpGIisfITm91skQzXYas2ALyhIafxV4bmcL2gzCFh1cJCpQ=="
     },
     "node_modules/string-math": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-pivot-table",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A markdown-it plugin to add pivot table support",
   "keywords": [
     "markdown-it",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "markdown-it": "^13.0.1"
   },
   "dependencies": {
-    "csv-to-markdown-table": "^1.3.1",
     "group-by": "^0.0.1",
+    "nd-table": "^1.2.2",
     "string-math": "^1.2.2"
   }
 }


### PR DESCRIPTION
The `csv-to-markdown-table` library did not allow options for escaping comma characters, leading to issues where the cell are splitting into multiple where they shouldn't.

Replacing the library with `nd-table` which works a lot more in an object oriented manner, and eliminates the escape problems.
